### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,10 +8,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v1
+              uses: actions/checkout@v3
             - name: Run Labeler
               if: success()
-              uses: crazy-max/ghaction-github-labeler@v1
+              uses: crazy-max/ghaction-github-labeler@v4
               with:
                   yaml_file: .github/labels.yml
                   skip_delete: false


### PR DESCRIPTION
Update actions and labeler versions to solve labeler Actions failing. `checkout@v1` uses node12 which has been depreciated on the Github side for node16.

Possibly needs syntax update based on ghaction-github-labeler docs?

Default options on labeler v4:

```
name: github

on:
  push:
    branches:
      - 'main'
    paths:
      - '.github/labels.yml'
      - '.github/workflows/labels.yml'

jobs:
  labeler:
    runs-on: ubuntu-latest
    steps:
      -
        name: Checkout
        uses: actions/checkout@v3
      -
        name: Run Labeler
        if: success()
        uses: crazy-max/ghaction-github-labeler@v4
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          yaml-file: .github/labels.yml
          skip-delete: false
          dry-run: false
          exclude: |
            help*
            *issue
```