### PR TITLE
Pitchfork Theme compatibility tweaks

### DIFF
--- a/unityblocks.php
+++ b/unityblocks.php
@@ -38,6 +38,12 @@ $pitchfork_theme = ( 'pitchfork' === $theme_data->get( 'TextDomain' ) || 'pitchf
  */
 function unityblocks_block_init()
 {
+	/**
+	 * Load current theme and check if it is Pitchfork or a Pitchfork Child
+	 */
+	$theme_data = wp_get_theme();
+	$pitchfork_theme = ( 'pitchfork' === $theme_data->get( 'TextDomain' ) || 'pitchfork' === $theme_data->get( 'Template' ) );
+
 	// Register these blocks only if not using Pitchfork
 	// Pitchfork already has these blocks
 	if ( $pitchfork_theme ) {

--- a/unityblocks.php
+++ b/unityblocks.php
@@ -24,6 +24,12 @@ if (!defined('ABSPATH')) {
 }
 
 /**
+ * Load current theme and check if it is Pitchfork or a Pitchfork Child
+ */
+$theme_data = wp_get_theme();
+$pitchfork_theme = ( 'pitchfork' === $theme_data->get( 'TextDomain' ) || 'pitchfork' === $theme_data->get( 'Template' ) );
+
+/**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it also registers all assets so they can be enqueued
  * through the block editor in the corresponding context.
@@ -32,15 +38,22 @@ if (!defined('ABSPATH')) {
  */
 function unityblocks_block_init()
 {
+	// Register these blocks only if not using Pitchfork
+	// Pitchfork already has these blocks
+	if ( $pitchfork_theme ) {
+		register_block_type( __DIR__ . '/build/hero' );
+	}
+
 	register_block_type(__DIR__ . '/build/anchor-menu');
-	register_block_type(__DIR__ . '/build/hero');
+	register_block_type(__DIR__ . '/build/asu-careers');
 	register_block_type(__DIR__ . '/build/events-grid');
-	register_block_type(__DIR__ . '/build/events-list');
 	register_block_type(__DIR__ . '/build/image-gallery');
 	register_block_type(__DIR__ . '/build/news-grid');
-	register_block_type(__DIR__ . '/build/news-list');
 	register_block_type(__DIR__ . '/build/testimonial');
-	register_block_type(__DIR__ . '/build/asu-careers');
+
+	// Disable obsolete blocks - We may want to remove these blocks entirely
+	// register_block_type(__DIR__ . '/build/events-list');
+	// register_block_type(__DIR__ . '/build/news-list');
 }
 add_action('init', 'unityblocks_block_init');
 


### PR DESCRIPTION
This PR makes some initial tweaks to ensure full compatibility with the Pitchfork theme. The main change is adding logic to not register blocks that are already provided in Pitchfork.